### PR TITLE
Remove unneeded Python includes

### DIFF
--- a/src/pl/plpython/plpython.h
+++ b/src/pl/plpython/plpython.h
@@ -120,9 +120,6 @@ typedef int Py_ssize_t;
 #undef TEXTDOMAIN
 #define TEXTDOMAIN PG_TEXTDOMAIN("plpython")
 
-#include <compile.h>
-#include <eval.h>
-
 /* put back our snprintf and vsnprintf */
 #ifdef USE_REPL_SNPRINTF
 #ifdef snprintf


### PR DESCRIPTION
Inluding <compile.h> and <eval.h> has not been necessary since Python 2.4, since they are included via <Python.h>.  Morever, <eval.h> is being removed in Python 3.11.  So remove these includes.

Reviewed-by: Tom Lane <tgl@sss.pgh.pa.us>
Discussion: https://www.postgresql.org/message-id/flat/84884.1637723223%40sss.pgh.pa.us (cherry picked from commit 4339e10f090ec6b5ceb727c00e7a345cc9178e1e)
